### PR TITLE
corrige caminho hideModal

### DIFF
--- a/app/view/error.php
+++ b/app/view/error.php
@@ -51,7 +51,7 @@ function showModal()
 
 function hideModal() 
 {
-    window.location.replace("./index-cadastros.php");
+    window.location.replace("./pages/index-cadastros.php");
 }
 
 </script>


### PR DESCRIPTION
Resumo: corrige o caminho passado na função hideModal() em app/view/error.php.

Descrição: Esta alteração corrige o caminho passado na função hideModal() em app/view/error.php, que estava causando um erro de exibição na página de erro. O caminho correto foi atualizado para corrigir o erro e melhorar a usabilidade da página.